### PR TITLE
Fix: Actions Workflow to build and deploy to GH Pages was pointing to…

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -1,7 +1,7 @@
 name: Deploy Astro site to Pages
 on:
   push:
-    branches: ["master"]
+    branches: [ "main" ]
   workflow_dispatch:
 permissions:
   contents: read
@@ -66,6 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Deploy Website
         id: deployment
         uses: actions/deploy-pages@v2


### PR DESCRIPTION
Fix: Actions Workflow to build and deploy to GH Pages was pointing to "master" branch instead of "main"